### PR TITLE
delete using sql when there are no destroy callbacks defined

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -86,6 +86,11 @@ module ActiveRecord
 
         # Deletes the records according to the <tt>:dependent</tt> option.
         def delete_records(records, method)
+
+          if method == :destroy && reflection.klass._destroy_callbacks.empty?
+            method = :delete_all
+          end
+
           if method == :destroy
             records.each { |r| r.destroy }
             update_counter(-records.length) unless inverse_updates_counter_cache?


### PR DESCRIPTION
@ColinDKelley @jpterry  what are your thoughts on this? It will make :dependent => destroy smarter on a has_many association by taking the sql route for deleting when the model in question has no destroy callbacks. So when we do something like `BulkPendingEmail.last.destroy`,  and we have dependent => destroy defined it should delete the recipients this way:

DELETE FROM `bulk_pending_email_recipients` WHERE `bulk_pending_email_recipients`.`bulk_pending_email_id` = 21 AND `bulk_pending_email_recipients`.`id` IN (1, 2, 3, 4, 5, 6)
