### PR TITLE
Serialize triggers in schema files

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -199,7 +199,7 @@ module ActiveRecord
       # QUOTING ==================================================
 
       def quote(value, column = nil)
-        if value.kind_of?(String) && column && column.type == :binary && column.class.respond_to?(:string_to_binary)
+        if value.kind_of?(String) && column && [:binary, :varbinary].include?(column.type) && column.class.respond_to?(:string_to_binary)
           s = column.class.string_to_binary(value).unpack("H*")[0]
           "x'#{s}'"
         elsif value.kind_of?(BigDecimal)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -334,6 +334,15 @@ module ActiveRecord
         }.join
       end
 
+      def trigger_dump
+        triggers = ApplicationModel.connection.select_all("show triggers").map do |row|
+          ApplicationModel.connection.select_one("show create trigger #{row['Trigger']}")['SQL Original Statement'].sub(/ DEFINER.*TRIGGER/, ' TRIGGER') +
+            "\n//"
+        end
+
+        "DELIMITER //\n#{triggers.join("\n")}\nDELIMITER ;\n"
+      end
+
       # Drops the database specified on the +name+ attribute
       # and creates it again using the provided +options+.
       def recreate_database(name, options = {})

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -879,11 +879,7 @@ module ActiveRecord
     end
 
     def create_fixtures_from_yaml
-      #TODO - jpt - HACK: We destroy the triggers to allow fixtures to load and recreate them afterwards.
-      ApplicationModel.drop_triggers!
       fixtures = Fixtures.create_fixtures(fixture_path, fixture_table_names, fixture_class_names)
-      ApplicationModel.recreate_triggers!
-
       Hash[fixtures.map { |f| [f.name, f] }]
     end
 

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -450,6 +450,7 @@ EOS
         File.open(filename, "w+") do |f|
           f << MYSQL_DUMP_HEADER
           f << ActiveRecord::Base.connection.structure_dump.gsub(/AUTO_INCREMENT=\d+ /,'')
+          f << ActiveRecord::Base.connection.trigger_dump
           f << MYSQL_DUMP_FOOTER
         end
         #File.open(filename, "w:utf-8") { |f| f << ActiveRecord::Base.connection.structure_dump }


### PR DESCRIPTION
@jpterry @primiti  I found we were recreating triggers once for every fixture class! I removed that hack and much of the trigger code on the web/ repo side by simply including the triggers in the schema dump. :)
