### PR TITLE
primary key bug fix for MySQL 5.7 backported from Rails 4

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -111,7 +111,7 @@ module ActiveRecord
       QUOTED_TRUE, QUOTED_FALSE = '1', '0'
 
       NATIVE_DATABASE_TYPES = {
-        :primary_key              => "int(11) DEFAULT NULL auto_increment PRIMARY KEY",
+        :primary_key              => "int auto_increment PRIMARY KEY",
         :primary_key_no_increment => "int(11) PRIMARY KEY", #RingRevenue patch
         :string                   => { :name => "varchar", :limit => 255 },
         :text                     => { :name => "text" },


### PR DESCRIPTION
@cmparkinson @deltaroe Here's the fix for MySQL 5.7.  I backported the primary definition from Rails 4:

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L127
