### PR TITLE
Fix active record database task to use configuration instead of config

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -223,7 +223,7 @@ module ActiveRecord
           check_schema_file(file)
           # Invoca Patch - check that file exists and load file
           File.exists?(file) or abort %{#{file} doesn't exist yet. Run "rake db:migrate" to create it then try again. If you do not intend to use a database, you should instead alter #{Rails.root}/config/boot.rb to limit the frameworks that will be loaded}
-          command = "mysql '-u#{config["username"]}' '-p#{config["password"]}' '#{config["database"]}' < '#{file}'"
+          command = "mysql '-u#{configuration["username"]}' '-p#{configuration["password"]}' '#{configuration["database"]}' < '#{file}'"
           puts command if ENV['verbose'] != 'false'
           system( command )
           $?.success? or raise "load_schema_for failed executing `#{command}`"


### PR DESCRIPTION
Consider this PR largely as a question. I don't understand how this code works and I had to modify it locally to get my database tasks to work, but it has been in our fork of rails for 2 years. How does this code work? or why would it only not work on my computer? Maybe `db:structure:load` doesn't work today?