### PR TITLE
TECH-2803: in define_attribute_methods, load column_names before mutex synchronize

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -81,10 +81,11 @@ module ActiveRecord
         # Use a mutex; we don't want two threads simultaneously trying to define
         # attribute methods.
 
-        # TECH-2803: load the column_names before entering the mutex, since with em_mysql2, the columns method
+        # TECH-2803: load the column_names and primary_key before entering the mutex, since with em_mysql2, the columns method
         # will block when it reads from SQL and yield the fiber, then the next fiber that schedules may wind
-        # up right back here and try to re-enter the mutex...which will raise ThreadError: deadlock; recursive locking
+        # up right back here and try to re-enter the mutex...which will raise ThreadError, "deadlock; recursive locking"
         col_names = column_names
+        primary_key
         generated_attribute_methods.synchronize do
           return false if @attribute_methods_generated
           superclass.define_attribute_methods unless self == base_class


### PR DESCRIPTION
https://ringrevenue.atlassian.net/browse/TECH-2803