### PR TITLE
Rails issue 34790 patch

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -274,6 +274,12 @@ module ActionController
 
   class TestResponse < ActionDispatch::TestResponse
     def recycle!
+
+      # patch from https://github.com/rails/rails/issues/34790
+      # hack to avoid MonitorMixin double-initialize error:
+      @mon_mutex_owner_object_id = nil
+      @mon_mutex = nil
+
       initialize
     end
   end
@@ -281,6 +287,12 @@ module ActionController
   class LiveTestResponse < Live::Response
     def recycle!
       @body = nil
+
+      # patch from https://github.com/rails/rails/issues/34790
+      # hack to avoid MonitorMixin double-initialize error:
+      @mon_mutex_owner_object_id = nil
+      @mon_mutex = nil
+
       initialize
     end
 


### PR DESCRIPTION
Fix from https://github.com/rails/rails/issues/34790

It looks like Ruby 2.6 no longer allows mutexes to be initialized multiple times. The Rails test suite was doing that in a `recycle!` method that calls `initialize` on a`TestResponse` object that has previously been initialized. The fix is to `nil` out the mutexes and owner id before calling `initialize` again.