### PR TITLE
Invoca 4.2.11.3.1

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,19 @@
-## Rails 4.2.11.3 (May 15, 2020) ##
+*   Prevent string polymorphic route arguments.
+
+    `url_for` supports building polymorphic URLs via an array
+    of arguments (usually symbols and records). If a developer passes a
+    user input array, strings can result in unwanted route helper calls.
+
+    CVE-2021-22885
+
+    *Gannon McGibbon*
+
+## Rails 5.2.4.5 (February 10, 2021) ##
+
+*   No changes.
+
+
+## Rails 5.2.4.4 (September 09, 2020) ##
 
 *   No changes.
 

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -402,7 +402,7 @@ module ActionController
     module Token
       TOKEN_KEY = 'token='
       TOKEN_REGEX = /^Token /
-      AUTHN_PAIR_DELIMITERS = /(?:,|;|\t+)/
+      AUTHN_PAIR_DELIMITERS = /(?:,|;|\t)/
       extend self
 
       module ControllerMethods

--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -274,10 +274,12 @@ module ActionDispatch
 
           args = []
 
-          route  = record_list.map { |parent|
+          route = record_list.map do |parent|
             case parent
-            when Symbol, String
+            when Symbol
               parent.to_s
+            when String
+              raise(ArgumentError, "Please use symbols for polymorphic route arguments.")
             when Class
               args << parent
               parent.model_name.singular_route_key
@@ -285,12 +287,14 @@ module ActionDispatch
               args << parent.to_model
               parent.to_model.model_name.singular_route_key
             end
-          }
+          end
 
           route <<
           case record
-          when Symbol, String
+          when Symbol
             record.to_s
+          when String
+            raise(ArgumentError, "Please use symbols for polymorphic route arguments.")
           when Class
             @key_strategy.call record.model_name
           else

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -87,6 +87,31 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     assert_equal "HTTP Token: Access denied.\n", @response.body, "Authentication header was not properly parsed"
   end
 
+  test "authentication request with evil header" do
+    @request.env["HTTP_AUTHORIZATION"] = "Token ." + " " * (1024*80-8) + "."
+    Timeout.timeout(1) do
+      get :index
+    end
+
+    assert_response :unauthorized
+    assert_equal "HTTP Token: Access denied.\n", @response.body, "Authentication header was not properly parsed"
+  end
+
+  test "successful authentication request with Bearer instead of Token" do
+    @request.env["HTTP_AUTHORIZATION"] = "Bearer lifo"
+    get :index
+
+    assert_response :success
+  end
+
+  test "authentication request with tab in header" do
+    @request.env["HTTP_AUTHORIZATION"] = "Token\ttoken=\"lifo\""
+    get :index
+
+    assert_response :success
+    assert_equal "Hello Secret", @response.body
+  end
+
   test "authentication request without credential" do
     get :display
 

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -90,6 +90,14 @@ class RedirectController < ActionController::Base
     redirect_to nil
   end
 
+  def redirect_to_polymorphic
+    redirect_to [:internal, Workshop.new(5)]
+  end
+
+  def redirect_to_polymorphic_string_args
+    redirect_to ["internal", Workshop.new(5)]
+  end
+
   def redirect_to_params
     redirect_to ActionController::Parameters.new(status: 200, protocol: 'javascript', f: '%0Aeval(name)')
   end
@@ -276,6 +284,43 @@ class RedirectTest < ActionController::TestCase
       get :redirect_to_new_record
       assert_equal "http://test.host/workshops", redirect_to_url
       assert_redirected_to Workshop.new(nil)
+    end
+  end
+
+  def test_polymorphic_redirect
+    with_routing do |set|
+      set.draw do
+        namespace :internal do
+          resources :workshops
+        end
+
+        ActiveSupport::Deprecation.silence do
+          get ":controller/:action"
+        end
+      end
+
+      get :redirect_to_polymorphic
+      assert_equal "http://test.host/internal/workshops/5", redirect_to_url
+      assert_redirected_to [:internal, Workshop.new(5)]
+    end
+  end
+
+  def test_polymorphic_redirect_with_string_args
+    with_routing do |set|
+      set.draw do
+        namespace :internal do
+          resources :workshops
+        end
+
+        ActiveSupport::Deprecation.silence do
+          get ":controller/:action"
+        end
+      end
+
+      error = assert_raises(ArgumentError) do
+        get :redirect_to_polymorphic_string_args
+      end
+      assert_equal("Please use symbols for polymorphic route arguments.", error.message)
     end
   end
 

--- a/actionview/test/activerecord/polymorphic_routes_test.rb
+++ b/actionview/test/activerecord/polymorphic_routes_test.rb
@@ -459,12 +459,6 @@ class PolymorphicRoutesTest < ActionController::TestCase
     end
   end
 
-  def test_with_array_containing_single_string_name
-    with_test_routes do
-      assert_url "http://example.com/projects", ["projects"]
-    end
-  end
-
   def test_with_array_containing_symbols
     with_test_routes do
       assert_url "http://example.com/series/new", [:new, :series]
@@ -616,6 +610,22 @@ class PolymorphicRoutesTest < ActionController::TestCase
   def test_nested_routing_to_a_model_delegate
     with_test_routes do
       assert_url "http://example.com/foo/model_delegates/overridden", [:foo, @delegator]
+    end
+  end
+
+  def test_string_route_arguments
+    with_admin_test_routes do
+      error = assert_raises(ArgumentError) do
+        polymorphic_url(["admin", @project])
+      end
+
+      assert_equal("Please use symbols for polymorphic route arguments.", error.message)
+
+      error = assert_raises(ArgumentError) do
+        polymorphic_url([@project, "bid"])
+      end
+
+      assert_equal("Please use symbols for polymorphic route arguments.", error.message)
     end
   end
 


### PR DESCRIPTION
Back-port changes for these CVEs from Rails 5-2-stable:
```
Name: actionpack
Version: 4.2.11.3
Advisory: CVE-2021-22904
Criticality: Unknown
URL: https://groups.google.com/g/rubyonrails-security/c/Pf1TjkOBdyQ
Title: Possible DoS Vulnerability in Action Controller Token Authentication
Solution: upgrade to ~> 5.2.4.6, ~> 5.2.6, ~> 6.0.3.7, >= 6.1.3.2

Name: actionpack
Version: 4.2.11.3
Advisory: CVE-2021-22885
Criticality: Unknown
URL: https://groups.google.com/g/rubyonrails-security/c/NiQl-48cXYI
Title: Possible Information Disclosure / Unintended Method Execution in Action Pack
Solution: upgrade to ~> 5.2.4.6, ~> 5.2.6, ~> 6.0.3.7, >= 6.1.3.2
```